### PR TITLE
CAS v6.6 Upgrade Fixes

### DIFF
--- a/gatech_aws_credentials.py
+++ b/gatech_aws_credentials.py
@@ -7,7 +7,6 @@ https://aws.amazon.com/blogs/security/how-to-implement-federated-api-and-cli-acc
 import base64
 import logging
 import sys
-import xml.etree.ElementTree as ElementTree
 from argparse import ArgumentParser
 from configparser import ConfigParser
 from datetime import datetime, timezone
@@ -17,7 +16,8 @@ from json import dumps
 from os import mkdir, path
 from re import search
 from typing import Dict, List, Optional, Tuple, Union
-from urllib.parse import quote, urlparse, parse_qs
+from urllib.parse import parse_qs, quote, urlparse
+from xml.etree import ElementTree
 
 import boto3  # type: ignore
 
@@ -32,7 +32,9 @@ from requests import Session
 
 # Defaults
 DEFAULT_CAS_HOST = "sso.gatech.edu"
-DEFAULT_SAML_URL = "https://sso.gatech.edu/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices"
+DEFAULT_SAML_URL = (
+    "https://sso.gatech.edu/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices"
+)
 
 # Errors handled in several places
 ERROR_INVALID_CREDENTIALS_IN_KEYRING = (
@@ -118,7 +120,7 @@ def get_ticket_granting_ticket_url(
         GET_TGT_URL.format(hostname=hostname), data={USERNAME: username, PASSWORD: password},
     )
 
-    if response.status_code == 423 or response.status_code == 401:
+    if response.status_code in (423, 401):
         return response.status_code, None
 
     tgt_url = BeautifulSoup(response.text, HTML_PARSER).form["action"]
@@ -142,7 +144,11 @@ def get_saml_response(session: Session, saml_url: str, tgt_url: str) -> Optional
     start_request = session.get(saml_url, allow_redirects=False)
 
     if start_request.status_code != 302:
-        logger.error(ERROR_UNEXPECTED_RESPONSE_CODE.format(code=start_request.status_code, action="starting SAML flow"))
+        logger.error(
+            ERROR_UNEXPECTED_RESPONSE_CODE.format(
+                code=start_request.status_code, action="starting SAML flow"
+            )
+        )
 
     callback_location = start_request.headers.get("Location")
 

--- a/gatech_aws_credentials.py
+++ b/gatech_aws_credentials.py
@@ -32,7 +32,7 @@ from requests import Session
 
 # Defaults
 DEFAULT_CAS_HOST = "sso.gatech.edu"
-DEFAULT_SAML_URL = "https://sso.gatech.edu/cas/idp/profile/SAML2/Callback?entityId=urn%3Aamazon%3Awebservices"
+DEFAULT_SAML_URL = "https://sso.gatech.edu/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices"
 
 # Errors handled in several places
 ERROR_INVALID_CREDENTIALS_IN_KEYRING = (
@@ -139,7 +139,7 @@ def get_saml_response(session: Session, saml_url: str, tgt_url: str) -> Optional
     """
     logger = logging.getLogger()
 
-    start_request = session.get("https://sso.gatech.edu/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices", allow_redirects=False)
+    start_request = session.get(saml_url, allow_redirects=False)
 
     if start_request.status_code != 302:
         logger.error(ERROR_UNEXPECTED_RESPONSE_CODE.format(code=start_request.status_code, action="starting SAML flow"))


### PR DESCRIPTION
GT upgraded their CAS deployment to server version v6.6 (from v6.1) on December 23rd and this broke thereafter due to some changes in how unsolicited/IdP-initiated SAML2 logins are processed. In theory what's here _should_ work, but CAS is throwing 500 errors on ST redemption as of my last test. I'll follow up with the IAM team after the new year (assuming it's still broken) to see what the heck is going on.

The main difference is that you no longer need to generate a SAML request (formerly `GET https://idp.gatech.edu/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices`, and then parse out the SAML payload) prior to requesting an ST. Instead, you start the SAML flow (after TGT generation) by requesting the ST with the service set to the unsolicited SAML URL. The assertion is generated automatically upon ST redemption.

![image](https://user-images.githubusercontent.com/1007666/209279679-c87b63aa-07d0-4e50-a050-c30ba8bf246a.png)
